### PR TITLE
Canvas type improvements

### DIFF
--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -8,7 +8,7 @@ import { createTouchEvents } from './events'
 import { RootState, Size } from '../core/store'
 import { polyfills } from './polyfills'
 
-export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dpr'>, ViewProps {
+export interface Props extends Omit<RenderProps, 'size' | 'dpr'>, ViewProps {
   children: React.ReactNode
   style?: ViewStyle
 }
@@ -59,7 +59,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
     if (error) throw error
 
     const viewRef = React.useRef<View>(null!)
-    const root = React.useRef<ReconcilerRoot<Element>>(null!)
+    const root = React.useRef<ReconcilerRoot>(null!)
 
     // Inject and cleanup RN polyfills if able
     React.useLayoutEffect(() => polyfills(), [])
@@ -82,7 +82,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
         getContext: (() => context) as any,
       } as HTMLCanvasElement
 
-      root.current = createRoot<Element>(canvasShim)
+      root.current = createRoot(canvasShim)
       setCanvas(canvasShim)
     }, [])
 

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -6,7 +6,7 @@ import { SetBlock, Block, ErrorBoundary, useMutableCallback, useIsomorphicLayout
 import { ReconcilerRoot, extend, createRoot, unmountComponentAtNode, RenderProps } from '../core'
 import { createPointerEvents } from './events'
 
-export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends Omit<RenderProps, 'size'>, React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
   /** Canvas fallback content, similar to img's alt prop */
   fallback?: React.ReactNode
@@ -65,10 +65,10 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(f
   // Throw exception outwards if anything within canvas throws
   if (error) throw error
 
-  const root = React.useRef<ReconcilerRoot<HTMLElement>>(null!)
+  const root = React.useRef<ReconcilerRoot>(null!)
 
   if (containerRect.width > 0 && containerRect.height > 0 && canvas) {
-    if (!root.current) root.current = createRoot<HTMLElement>(canvas)
+    if (!root.current) root.current = createRoot(canvas)
     root.current.configure({
       gl,
       events,

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -70,7 +70,7 @@ beforeAll(() => {
 })
 
 describe('renderer', () => {
-  let root: ReconcilerRoot<HTMLCanvasElement> = null!
+  let root: ReconcilerRoot = null!
 
   beforeEach(() => {
     const canvas = createCanvas({

--- a/packages/test-renderer/src/types/public.ts
+++ b/packages/test-renderer/src/types/public.ts
@@ -15,7 +15,7 @@ export type MockSyntheticEvent = {
   [key: string]: any
 }
 
-export type CreateOptions = CreateCanvasParameters & RenderProps<HTMLCanvasElement>
+export type CreateOptions = CreateCanvasParameters & RenderProps
 
 export type Act = (cb: () => Promise<any>) => Promise<any>
 


### PR DESCRIPTION
Improve typing on `createRoot` by declaring that it handles `HTMLCanvasElement | OffscreenCanvas`. This is more expressive than accepting any subclass of `Element` and allows some generic type params to be removed.